### PR TITLE
Enable static maps

### DIFF
--- a/src/main/js/core/map-directives.js
+++ b/src/main/js/core/map-directives.js
@@ -11,11 +11,11 @@ var app = angular.module('gawebtoolkit.core.map-directives', [ 'gawebtoolkit.cor
  * @param {string|@} mapElementId - The id of the element where the map is to be rendered
  * @param {string|@} datumProjection - A value representing the Datum Projection, eg 'EPSG:4326'
  * @param {string|@} displayProjection - A value representing the Display Projection, eg 'EPSG:4326'
- * @param {string|@=} centerPosition - A lon/lat value in the form of an array, eg [110,-55].
+ * @param {string|@=} centerPosition - A lat/lon value in the form of an array, eg [-55,110].
  * @param {number|@=} zoomLevel - An initial zoom value for the map to start at.
  * @param {geoJsonCoordinates|==} initialExtent - An initial extent is the form of a geoJson array of coordinates.
  * @param {string|@} framework - Optional. Default 'olv2'. Specifies which underlying mapping framework to use.
- *
+ * @param {bool|@} isStaticMap - Optional. Default to false. Creates the map without navigation/interaction controls.
  * @method addLayer - Adds a layer programmatically
  *
  * @scope
@@ -45,6 +45,7 @@ app.directive('gaMap', [ '$timeout', '$compile', 'GAMapService', 'GALayerService
             displayProjection: '@',
             centerPosition: '@',
             zoomLevel: '@',
+            isStaticMap:'@',
 			initialExtent: '=',
             framework:'@'
         },
@@ -1687,7 +1688,8 @@ app.directive('gaMap', [ '$timeout', '$compile', 'GAMapService', 'GALayerService
                 displayProjection: $scope.displayProjection,
                 initialExtent: $scope.initialExtent,
                 centerPosition: $scope.centerPosition,
-                zoomLevel: $scope.zoomLevel
+                zoomLevel: $scope.zoomLevel,
+                isStaticMap: $scope.isStaticMap
             }, $scope.framework);
 
             /**

--- a/src/main/js/map services/map-openlayersv2.js
+++ b/src/main/js/map services/map-openlayersv2.js
@@ -45,9 +45,11 @@ app.service('olv2MapService', [
 				config.numZoomLevels = mapConfig.defaultOptions.numZoomLevels;
 				config.displayProjection = args.displayProjection;
 
-				if (config.controls === undefined || config.controls === null) {
+				if ((!args.isStaticMap) && (config.controls === undefined || config.controls === null)) {
 					//TODO move defaults into angular config constant
 					config.controls = [ new OpenLayers.Control.Navigation() ];
+				} else {
+					config.controls = [];
 				}
 
 				return new OpenLayers.Map(args.mapElementId, config);

--- a/src/main/js/map services/map-openlayersv3.js
+++ b/src/main/js/map services/map-openlayersv3.js
@@ -58,7 +58,11 @@
                     config.renderer = appConfig.olv3Options == null ? 'canvas' : (appConfig.olv3Options.renderer || 'canvas');
 
                     config.view = view;
+                    if(args.isStaticMap) {
+                        config.interactions = [];
+                    }
                     config.controls = [];
+
                     service.displayProjection = args.displayProjection;
                     var map = new ol.Map(config);
 

--- a/src/test/js/unit/gawebtoolkit_olv2_mapSpec.js
+++ b/src/test/js/unit/gawebtoolkit_olv2_mapSpec.js
@@ -11,6 +11,7 @@
                 mapControllerListener,
                 layerService;
 
+            var mapThatIsStatic;
             // Load the myApp module, which contains the directive
             beforeEach(module('testApp'));
 
@@ -54,9 +55,7 @@
                         "coordinates": [ 117.359, -25.284 ]
                     }
                 };
-
-                element = angular
-                    .element('<ga-map map-element-id="gamap" datum-projection="EPSG:102100" display-projection="EPSG:4326"' +
+                var ele = '<ga-map map-element-id="gamap" is-static-map="true" datum-projection="EPSG:102100" display-projection="EPSG:4326"' +
                     'initial-extent="[[100.0,-10.0],[160.0,-10],[100.0,-45.0],[160.0,-45.0]]">' +
                     '<ga-map-layer layer-name="Australian Landsat Mosaic"' +
                     'layer-url="http://www.ga.gov.au/gisimg/services/topography/World_Bathymetry_Image_WM/MapServer/WMSServer"' +
@@ -72,7 +71,10 @@
                     '</ga-feature-layer>' +
                     '<ga-map-control map-control-name="OverviewMap" map-control-id="myOverviewTestId"></ga-map-control>' +
                     '<div id="gamap"></div>' +
-                    '</ga-map>');
+                    '</ga-map>';
+                element = angular
+                    .element(ele);
+                mapThatIsStatic = ele.replace('map-element-id="map"','map-element-id="map" is-static-map="true"');
                 $compile(element)($scope);
                 $scope.$digest();
                 $timeout.flush();
@@ -185,6 +187,9 @@
                 } catch (e) {
                 }
                 expect(passed).toBe(true);
+            });
+            it('Should have no controls listed when created as a static map.', function () {
+                expect($scope.mapController.getMapInstance().controls.length).toBe(1); //Overview map in html template
             });
             it('Should fire mapController function "getLonLatFromPixel" without an exception given valid input', function () {
                 var passed = false;

--- a/src/test/js/unit/gawebtoolkit_olv3_mapSpec.js
+++ b/src/test/js/unit/gawebtoolkit_olv3_mapSpec.js
@@ -11,7 +11,7 @@
                 mapControllerListener;
 
             var mapWith3DSupportedProj;
-
+            var mapThatIsStatic;
 
             // Load the myApp module, which contains the directive
             beforeEach(module('testApp'));
@@ -80,6 +80,8 @@
                     '<ga-map-control map-control-name="scaleline" map-control-id="myScaleLineTestId"></ga-map-control> ' +
                     '</ga-map> ';
                 mapWith3DSupportedProj = ele.replace('EPSG:102100','EPSG:3857');
+
+                mapThatIsStatic = ele.replace('map-element-id="map"','map-element-id="map" is-static-map="true"');
                 element = angular
                     .element(ele);
                 $compile(element)($scope);
@@ -210,6 +212,15 @@
                 var controls = $scope.mapController.getMapInstance().getControls();
                 expect(controls != null).toBe(true);
                 expect(controls.getLength()).toBe(2);
+            });
+
+            it('Should have no interactions listed when created as a static map.', function () {
+                element = angular
+                    .element(mapThatIsStatic);
+                $compile(element)($scope);
+                $scope.$digest();
+                $timeout.flush();
+                expect($scope.mapController.getMapInstance().getInteractions().getLength()).toBe(0);
             });
             // TODO Can't test getLonLatFromPixel due to way OLV3 relies on the rendered frame.
             /*it('Should fire mapController function "getLonLatFromPixel" without an exception given valid input', function () {


### PR DESCRIPTION
Added the ability to make the map non-interaction via `is-static-map` attribute on `ga-map` directive.

Added tests, updated doco/comments.