### PR TITLE
Map marker directive improvements.

### DIFF
--- a/src/main/js/core/layer-services.js
+++ b/src/main/js/core/layer-services.js
@@ -33,6 +33,11 @@ app.service('GALayerService', ['ga.config', 'mapLayerServiceLocator', function (
             var service = mapLayerServiceLocator.getImplementation(useVersion);
             return service.createOsmLayer(args);
         },
+        createMarkerLayer: function (args, version) {
+            var useVersion = version || 'olv2';
+            var service = mapLayerServiceLocator.getImplementation(useVersion);
+            return service.createMarkerLayer(args);
+        },
         removeLayerByName: function (mapInstance, layerName,version) {
             var useVersion = version || 'olv2';
             var service = mapLayerServiceLocator.getImplementation(useVersion);

--- a/src/main/js/core/map-services.js
+++ b/src/main/js/core/map-services.js
@@ -169,7 +169,12 @@ app.service('GAMapService', ['$log', 'ga.config', 'mapServiceLocator',
             setMapMarker: function (mapInstance, coords, markerGroupName, iconUrl, args, version) {
                 var useVersion = version || 'olv2';
                 var service = mapServiceLocator.getImplementation(useVersion);
-                service.setMapMarker(mapInstance, coords, markerGroupName, iconUrl, args);
+                return service.setMapMarker(mapInstance, coords, markerGroupName, iconUrl, args);
+            },
+            removeMapMarker: function(mapInstance,markerId,version) {
+                var useVersion = version || 'olv2';
+                var service = mapServiceLocator.getImplementation(useVersion);
+                service.removeMapMarker(mapInstance,markerId);
             },
             getLonLatFromPixel: function (mapInstance, x, y, projection, version) {
                 var useVersion = version || 'olv2';

--- a/src/main/js/core/marker-directives.js
+++ b/src/main/js/core/marker-directives.js
@@ -1,45 +1,105 @@
-var angular = angular || {};
+/* global angular */
+(function () {
+    "use strict";
+    var app = angular.module('gawebtoolkit.core.marker-directives',
+        [
+            'gawebtoolkit.core.map-directives',
+            'gawebtoolkit.core.map-services',
+            'gawebtoolkit.core.layer-services'
+        ]);
 
-var app = angular.module('gawebtoolkit.core.marker-directives',
-    [
-        'gawebtoolkit.core.map-directives',
-        'gawebtoolkit.core.map-services',
-        'gawebtoolkit.core.layer-services'
-    ]);
+    /**
+     * @ngdoc directive
+     * @name gawebtoolkit.core.marker-directives:gaMapMarker
+     * @param {string|@} markerIcon - Marker icon url
+     * @param {string|@} markerLat - Latitude for the marker
+     * @param {string|@} markerLong - Longitude for the marker
+     * @param {string|@} markerWidth - Width set for the marker icon
+     * @param {string|@} markerHeight - Height set for the marker icon
+     * @param {string|@} layerName - A name allocated to the marker
+     * @description
+     * A wrapper for a native map marker
+     * @scope
+     * @restrict E
+     * @require gaMap
+     * @example
+     */
+    app.directive('gaMapMarker', ['$log','$timeout','GALayerService', function ($log,$timeout,GALayerService) {
+        return {
+            restrict: "E",
+            require: "^gaMap",
+            scope: {
+                markerIcon: "@",
+                markerLong: "@",
+                markerLat: "@",
+                markerId: "@",
+                markerWidth: "@",
+                markerHeight: "@",
+                mapMarkerClicked: "&",
+                // Default is to create a layer per marker,
+                // but layer name can be provided to group all the markers on a single layer
+                layerName: "@"
+            },
+            link: function ($scope, element, attrs, mapController) {
+                $scope.framework = mapController.getFrameworkVersion();
+                attrs.$observe('markerIcon', function (newVal) {
 
-/**
- * @ngdoc directive
- * @name gawebtoolkit.core.marker-directives:gaMapMarker
- * @description
- * A wrapper for a native map marker
- * @scope
- * @restrict E
- * @require gaMap
- * @example
- */
-app.directive('gaMapMarker', [ function () {
-    'use strict';
-    return {
-        restrict: "E",
-        require: "^gaMap",
-        scope: {
-            markerIcon: "@",
-            markerLong: "@",
-            markerLat: "@",
-            markerId: "@",
-            mapMarkerClicked: "&"
-        },
-        link: function (scope, element, attrs, mapController) {
-            element.bind("click", function () {
-                scope.mapMarkerClicked({
-                    id: scope.markerId
                 });
-            });
 
-            if (!scope.mapControlName) {
-                return;
+                attrs.$observe('markerLong', function (newVal) {
+
+                });
+
+                attrs.$observe('markerLat', function (newVal) {
+
+                });
+
+                attrs.$observe('markerId', function (newVal) {
+
+                });
+
+                attrs.$observe('markerWidth', function (newVal) {
+
+                });
+                attrs.$observe('markerHeight', function (newVal) {
+
+                });
+
+
+                function createMapMarker() {
+                    var lat,lon,width,height, iconUrl;
+                    iconUrl = $scope.markerIcon;
+
+
+                    if(typeof $scope.markerLong === 'string') {
+                        lon = parseFloat($scope.markerLong);
+                    }
+
+                    if(typeof $scope.markerLat === 'string') {
+                        lat = parseFloat($scope.markerLat);
+                    }
+
+                    if(typeof $scope.markerWidth === 'string') {
+                        width = parseInt($scope.markerWidth);
+                    }
+
+                    if(typeof $scope.markerHeight === 'string') {
+                        height = parseInt($scope.markerHeight);
+                    }
+                    var layer = GALayerService.createLayer({layerType:'markerlayer',layerName: $scope.layerName },$scope.framework);
+                    mapController.addMarkerLayer(layer, $scope.layerName).then(function () {
+                        //Force digest to process initial async layers in correct order
+                        var position = mapController.getPixelFromLonLat(lon, lat);
+                        $scope.markerDto = mapController.setMapMarker(position,$scope.layerName,iconUrl,{width:width,height:height});
+
+                    });
+                }
+                createMapMarker();
+
+                $scope.$on('$destroy', function () {
+                    mapController.removeMapMarker($scope.markerDto.id);
+                });
             }
-            mapController.addControl(scope.mapControlName, scope.controlOptions, element);
-        }
-    };
-} ]);
+        };
+    }]);
+})();

--- a/src/main/js/core/services.js
+++ b/src/main/js/core/services.js
@@ -17,17 +17,17 @@ app.service('GAWTUtils', [ function() {
          });
       },
       convertHexToRgb: function (hexVal) {
-         function hexToR(h) {return parseInt((cutHex(h)).substring(0,2),16)}
-         function hexToG(h) {return parseInt((cutHex(h)).substring(2,4),16)}
-         function hexToB(h) {return parseInt((cutHex(h)).substring(4,6),16)}
-         function cutHex(h) {return (h.charAt(0)=="#") ? h.substring(1,7):h}
+         function hexToR(h) {return parseInt((cutHex(h)).substring(0,2),16);}
+         function hexToG(h) {return parseInt((cutHex(h)).substring(2,4),16);}
+         function hexToB(h) {return parseInt((cutHex(h)).substring(4,6),16);}
+         function cutHex(h) {return (h.charAt(0)==="#") ? h.substring(1,7):h;}
          return [hexToR(hexVal),hexToG(hexVal),hexToB(hexVal)];
       },
       convertHexAndOpacityToRgbArray: function (hexVal, opacity) {
-         function hexToR(h) {return parseInt((cutHex(h)).substring(0,2),16)}
-         function hexToG(h) {return parseInt((cutHex(h)).substring(2,4),16)}
-         function hexToB(h) {return parseInt((cutHex(h)).substring(4,6),16)}
-         function cutHex(h) {return (h.charAt(0)=="#") ? h.substring(1,7):h}
+         function hexToR(h) {return parseInt((cutHex(h)).substring(0,2),16);}
+         function hexToG(h) {return parseInt((cutHex(h)).substring(2,4),16);}
+         function hexToB(h) {return parseInt((cutHex(h)).substring(4,6),16);}
+         function cutHex(h) {return (h.charAt(0)==="#") ? h.substring(1,7):h;}
          return [hexToR(hexVal),hexToG(hexVal),hexToB(hexVal), opacity];
       }
 

--- a/src/main/js/map services/layer-openlayersv2.js
+++ b/src/main/js/map services/layer-openlayersv2.js
@@ -16,25 +16,28 @@ app.service('olv2LayerService', [ '$log', '$q','$timeout', function ($log, $q,$t
         createLayer: function (args) {
             var layer;
             //var options = service.defaultLayerOptions(args);
-            switch (args.layerType) {
-                case 'WMS':
+            switch (args.layerType.toLowerCase()) {
+                case 'wms':
                     layer = service.createWMSLayer(args);
                     break;
-                case 'XYZTileCache':
+                case 'xyztilecache':
                     layer = service.createXYZLayer(args);
                     break;
-                case 'ArcGISCache':
+                case 'arcgiscache':
                     layer = service.createArcGISCacheLayer(args);
                     break;
-                case 'Vector':
+                case 'vector':
                     layer = service.createFeatureLayer(args);
                     break;
-                case 'GoogleStreet':
-                case 'GoogleHybrid':
-                case 'GoogleSatellite':
-                case 'GoogleTerrain':
-                    //Deprecated
+                case 'googlestreet':
+                case 'googlehybrid':
+                case 'googlesatellite':
+                case 'googleterrain':
+                    //Deprecated - use vendor specific directives
                     layer = service.createGoogleMapsLayer(args);
+                    break;
+                case 'markerlayer':
+                    layer = service.createMarkerLayer(args);
                     break;
                 default:
                     throw new Error(
@@ -163,6 +166,9 @@ app.service('olv2LayerService', [ '$log', '$q','$timeout', function ($log, $q,$t
 
 
             return layer;
+        },
+        createMarkerLayer: function (args) {
+            return new OpenLayers.Layer.Markers(args.layerName);
         },
         createGoogleMapsLayer: function (args) {
             var googleLayerType;
@@ -395,9 +401,11 @@ app.service('olv2LayerService', [ '$log', '$q','$timeout', function ($log, $q,$t
                 mapInstance.removeLayer(layers[i]);
             }
         },
-        //Deprecated. Anything using this method needs to change.
-        //If external, to use removeLayerById
-        //If internal to olv2server, just use olv2 removeLayer method
+        /*
+        Deprecated. Anything using this method needs to change.
+        If external, to use removeLayerById
+        If internal to olv2service, just use olv2 removeLayer method
+        */
         removeLayer: function (mapInstance, layerInstance) {
             mapInstance.removeLayer(layerInstance);
         },

--- a/src/main/js/map services/layer-openlayersv3.js
+++ b/src/main/js/map services/layer-openlayersv3.js
@@ -27,6 +27,9 @@
                     case 'Vector':
                         layer = service.createFeatureLayer(args);
                         break;
+                    case 'markerlayer':
+                        layer = service.createMarkerLayer(args);
+                        break;
                     case 'GoogleStreet':
                     case 'GoogleHybrid':
                     case 'GoogleSatellite':
@@ -100,6 +103,14 @@
                 layer.set('isBaseLayer', args.isBaseLayer || false);
 
                 return layer;
+            },
+            createMarkerLayer: function (args) {
+                var result = new ol.layer.Vector({
+                    source: new ol.source.Vector(),
+                    format: new ol.format.GeoJSON()
+                });
+                result.set('name', args.layerName);
+                return result;
             },
             createGoogleLayer: function (args) {
                 throw new Error("Google map layers are not supported with OpenLayers 3. To use a Google maps layer, consider falling back to framework 'olv2'.");

--- a/src/main/js/map services/map-openlayersv2.js
+++ b/src/main/js/map services/map-openlayersv2.js
@@ -415,7 +415,7 @@ app.service('olv2MapService', [
 				}
 			},
 			setMapMarker: function (mapInstance, coords, markerGroupName, iconUrl, args) {
-				var markerLayer = mapInstance.getLayersBy('name', markerGroupName);
+				var markersLayers = mapInstance.getLayersBy('name', markerGroupName);
 
 				var opx = mapInstance.getLonLatFromPixel(coords);
 
@@ -424,15 +424,32 @@ app.service('olv2MapService', [
 				var icon = new OpenLayers.Icon(iconUrl, size, offset);
 				var marker = new OpenLayers.Marker(opx, icon.clone());
 				marker.map = mapInstance;
-
+				var id = GAWTUtils.generateUuid();
+				marker.id = id;
 				// Marker layer exists so get the layer and add the marker
-				if (markerLayer != null && markerLayer.length > 0) {
-					markerLayer[0].addMarker(marker);
+				if (markersLayers != null && markersLayers.length > 0 && typeof markersLayers[0].addMarker === 'function') {
+					markersLayers[0].addMarker(marker);
 				} else { // Marker layer does not exist so we create the layer then add the marker
 					var markers = new OpenLayers.Layer.Markers(markerGroupName);
 
 					mapInstance.addLayer(markers);
 					markers.addMarker(marker);
+				}
+				return {id: id, groupName: markerGroupName};
+			},
+			removeMapMarker: function(mapInstance, markerId) {
+				for (var i = 0; i < mapInstance.layers.length; i++) {
+					var layer = mapInstance.layers[i];
+					if(layer.markers != null && layer.markers.length > 0) {
+						for (var j = 0; j < layer.markers.length; j++) {
+							var marker = layer.markers[j];
+							if(marker.id === markerId) {
+								layer.removeMarker(marker);
+								break;
+							}
+						}
+						break;
+					}
 				}
 			},
 			getLonLatFromPixel: function (mapInstance, x, y, projection) {
@@ -464,7 +481,11 @@ app.service('olv2MapService', [
 				if (lat == null) {
 					throw new ReferenceError("'lat' value cannot be null or undefined");
 				}
-				return mapInstance.getPixelFromLonLat(new OpenLayers.LonLat(lon, lat));
+				var pos = new OpenLayers.LonLat(lon, lat);
+				if (service.displayProjection && service.displayProjection !== mapInstance.projection) {
+					pos = pos.transform(service.displayProjection, mapInstance.projection);
+				}
+				return mapInstance.getPixelFromLonLat(pos);
 			},
 			getPointFromEvent: function (e) {
 				// Open layers requires the e.xy object, be careful not to use e.x and e.y will return an

--- a/src/main/js/map services/map-openlayersv3.js
+++ b/src/main/js/map services/map-openlayersv3.js
@@ -703,7 +703,8 @@
                     var iconFeature = new ol.Feature({
                         geometry: new ol.geom.Point(latLon)
                     });
-                    iconFeature.setId(GAWTUtils.generateUuid());
+                    var id = GAWTUtils.generateUuid();
+                    iconFeature.setId(id);
 
                     var iconStyle = new ol.style.Style({
                         image: new ol.style.Icon(/** @type {olx.style.IconOptions} */ ({
@@ -728,6 +729,23 @@
                         });
                         markerLayer.set('name', markerGroupName);
                         mapInstance.addLayer(markerLayer);
+                    }
+                    return { id: id, groupName: markerGroupName};
+                },
+                removeMapMarker: function(mapInstance, markerId) {
+                    for (var i = 0; i < mapInstance.getLayers().getLength(); i++) {
+                        var layer = mapInstance.getLayers().item(i);
+                        var source = layer.getSource();
+                        if(typeof source.getFeatures === 'function' && source.getFeatures().length > 0) {
+                            for (var j = 0; j < source.getFeatures().length; j++) {
+                                var marker = source.getFeatures()[j];
+                                if(marker.getId() === markerId) {
+                                    source.removeFeature(marker);
+                                    break;
+                                }
+                            }
+                            break;
+                        }
                     }
                 },
                 getLonLatFromPixel: function (mapInstance, x, y, projection) {
@@ -759,7 +777,15 @@
                     if (lat == null) {
                         throw new ReferenceError("'lat' value cannot be null or undefined");
                     }
-                    return mapInstance.getPixelFromCoordinate([lon, lat]);
+                    var pos = [lon, lat];
+                    if(service.displayProjection !== mapInstance.getView().getProjection().getCode()) {
+                        pos = ol.proj.transform(pos, service.displayProjection, mapInstance.getView().getProjection());
+                    }
+                    var result = mapInstance.getPixelFromCoordinate(pos);
+                    return {
+                        x: result[0],
+                        y: result[1]
+                    };
                 },
                 getPointFromEvent: function (e) {
                     // Open layers requires the e.xy object, be careful not to use e.x and e.y will return an

--- a/src/main/js/map services/map-openlayersv3.js
+++ b/src/main/js/map services/map-openlayersv3.js
@@ -782,6 +782,8 @@
                         pos = ol.proj.transform(pos, service.displayProjection, mapInstance.getView().getProjection());
                     }
                     var result = mapInstance.getPixelFromCoordinate(pos);
+                    //Due to olv3 rendering async, function getPixelFromCoordinate may return null and a force render is required.
+                    if(result == null) mapInstance.renderSync();result = mapInstance.getPixelFromCoordinate(pos);
                     return {
                         x: result[0],
                         y: result[1]

--- a/src/test/examples/markers/markers-v2.html
+++ b/src/test/examples/markers/markers-v2.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html ng-app="simpleMap">
+<head lang="en">
+    <meta charset="UTF-8">
+    <script src="../../../../bower_components/proj4/dist/proj4.js"></script>
+    <script src="../../../../node_modules/openlayers/dist/ol-debug.js"></script>
+    <script src="../../../../external/OpenLayers2/OpenLayers.js"></script>
+    <script src="../../../../bower_components/jquery/dist/jquery.js"></script>
+    <script src="../../../../bower_components/angular-ui-bootstrap/misc/test-lib/angular.js"></script>
+    <script src="../../../../dist/geo-web-toolkit-min.js"></script>
+    <script src="http://epsg.io/21781-1753.js" type="text/javascript"></script>
+    <link rel="stylesheet" href="../../../../node_modules/openlayers/dist/ol.css"/>
+    <script src="http://maps.google.com/maps/api/js?sensor=false&.js&libraries=places"></script>
+    <title>OpenLayers 2 Drawing example</title>
+</head>
+<body ng-controller="mainController">
+<h1>Markers OpenLayers 2</h1>
+<div id="map" style="width:100%;height:500px;"></div>
+<ga-map map-element-id="map" zoom-level="4" center-position="[130, -25]">
+    <ga-osm-layer></ga-osm-layer>
+    <ga-map-marker layer-name="my marker group"
+                   marker-lat="-20"
+                   marker-long="130"
+                   marker-icon="http://upload.wikimedia.org/wikipedia/commons/8/86/Map_marker_icon_%E2%80%93_Nicolas_Mollet_%E2%80%93_Bowling_%E2%80%93_Culture_%26_Entertainment_%E2%80%93_Dark.png"
+                   marker-width="32" marker-height="37"></ga-map-marker>
+</ga-map>
+<script>
+    var app = angular.module('simpleMap',['gawebtoolkit.core']);
+    app.controller('mainController', ['$scope', function ($scope) {
+    }]);
+</script>
+</body>
+</html>

--- a/src/test/examples/markers/markers-v3.html
+++ b/src/test/examples/markers/markers-v3.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html ng-app="simpleMap">
+<head lang="en">
+    <meta charset="UTF-8">
+    <script src="../../../../bower_components/proj4/dist/proj4.js"></script>
+    <script src="../../../../node_modules/openlayers/dist/ol-debug.js"></script>
+    <script src="../../../../external/OpenLayers2/OpenLayers.js"></script>
+    <script src="../../../../bower_components/jquery/dist/jquery.js"></script>
+    <script src="../../../../bower_components/angular-ui-bootstrap/misc/test-lib/angular.js"></script>
+    <script src="../../../../dist/geo-web-toolkit-min.js"></script>
+    <script src="http://epsg.io/21781-1753.js" type="text/javascript"></script>
+    <link rel="stylesheet" href="../../../../node_modules/openlayers/dist/ol.css"/>
+    <script src="http://maps.google.com/maps/api/js?sensor=false&.js&libraries=places"></script>
+    <title>OpenLayers 2 Drawing example</title>
+</head>
+<body ng-controller="mainController">
+<h1>Markers OpenLayers 3</h1>
+<div id="map" style="width:100%;height:500px;"></div>
+<ga-map framework="olv3" map-element-id="map" zoom-level="4" center-position="[130, -25]">
+    <ga-osm-layer></ga-osm-layer>
+    <ga-map-marker layer-name="my marker group"
+           marker-lat="-20"
+           marker-long="130"
+           marker-icon="http://upload.wikimedia.org/wikipedia/commons/8/86/Map_marker_icon_%E2%80%93_Nicolas_Mollet_%E2%80%93_Bowling_%E2%80%93_Culture_%26_Entertainment_%E2%80%93_Dark.png"
+           marker-width="32" marker-height="37"></ga-map-marker>
+</ga-map>
+<script>
+    var app = angular.module('simpleMap',['gawebtoolkit.core']);
+    app.controller('mainController', ['$scope', function ($scope) {
+    }]);
+</script>
+</body>
+</html>

--- a/src/test/examples/vendor/bing-maps.html
+++ b/src/test/examples/vendor/bing-maps.html
@@ -19,13 +19,14 @@
 
 <ga-map ng-if="frameworkType != null" framework="{{frameworkType}}" map-element-id="map" zoom-level="4" center-position="[130, -25]">
     <ga-bing-layer bing-api-key="AjHzO1foSTb67AHZKdT3uc_aupuJ1reD3YUVP9yaKwgj1dePq8lAiPU-uPsEFtnT" wrap-date-line="'true'"></ga-bing-layer>
+
 </ga-map>
 <script>
     var app = angular.module('simpleMap',['gawebtoolkit.core']);
 
     app.controller('mainController', ['$scope','$timeout', function ($scope,$timeout) {
 
-        $scope.$on('mapControllerReady', function (mapController) {
+        $scope.$on('mapControllerReady', function (event, mapController) {
             $scope.mapController = mapController;
         });
         $scope.frameworkType = 'olv2';

--- a/src/test/examples/vendor/osm-maps.html
+++ b/src/test/examples/vendor/osm-maps.html
@@ -19,13 +19,19 @@
 <!-- Investigate bug limiting fullscreen size. WIDTH and HEIGHT values seem to be using size of window. -->
 <ga-map ng-if="frameworkType != null" framework="{{frameworkType}}" map-element-id="map" zoom-level="4" center-position="[130, -25]">
     <ga-osm-layer></ga-osm-layer>
+    <ga-map-marker layer-name="myMarkerLayer"
+                   marker-lat="-20"
+                   marker-long="130"
+                   marker-icon="http://localhost:8080/gamaps/content/marker/marker-legal.png"
+                   marker-height="50"
+                   marker-width="50" />
 </ga-map>
 <script>
     var app = angular.module('simpleMap',['gawebtoolkit.core']);
 
     app.controller('mainController', ['$scope','$timeout', function ($scope,$timeout) {
 
-        $scope.$on('mapControllerReady', function (mapController) {
+        $scope.$on('mapControllerReady', function (event,mapController) {
             $scope.mapController = mapController;
         });
         $scope.frameworkType = 'olv2';

--- a/src/test/js/unit/gawebtoolkit_olv2_mapSpec.js
+++ b/src/test/js/unit/gawebtoolkit_olv2_mapSpec.js
@@ -214,7 +214,7 @@
             it('Should fire mapController function "getPixelFromLonLat" without an exception given valid input', function () {
                 var passed = false;
                 try {
-                    var lonLat = $scope.mapController.getPixelFromLonLat(-20, 100);
+                    var lonLat = $scope.mapController.getPixelFromLonLat(130,-20);
                     expect(lonLat != null).toBe(true);
                     passed = true;
                 } catch (e) {
@@ -222,14 +222,22 @@
                 expect(passed).toBe(true);
             });
             it('Should fire mapController function "getPixelFromLonLat" with an exception given invalid input', function () {
-                var passed = false;
+                var lonPassed = false;
+                var latPassed = false
                 try {
-                    $scope.mapController.getPixelFromLonLat(null, null);
-                    passed = false;
-                } catch (e) {
-                    passed = true;
+                    $scope.mapController.getPixelFromLonLat(null, 123);
+                } catch(e) {
+                    lonPassed = true;
                 }
-                expect(passed).toBe(true);
+
+                try {
+                    $scope.mapController.getPixelFromLonLat(123, null);
+                } catch(e) {
+                    latPassed = true;
+                }
+
+                expect(lonPassed).toBe(true);
+                expect(latPassed).toBe(true);
             });
             it('Should fire mapController function "getPointFromEvent" without an exception given valid input', function () {
                 var passed = false;

--- a/src/test/js/unit/gawebtoolkit_olv2_markerSpec.js
+++ b/src/test/js/unit/gawebtoolkit_olv2_markerSpec.js
@@ -1,0 +1,134 @@
+/* global describe, beforeEach, module, angular, inject, it, expect, jasmine */
+(function () {
+    "use strict";
+
+    describe(
+        'OpenLayers v2 "ga-map-marker" implementation tests',
+        function () {
+            var $compile, $scope, $timeout, element, listener, preload;
+
+            // Load the myApp module, which contains the directive
+            beforeEach(module('testApp'));
+
+            // Store references to $rootScope and $compile
+            // so they are available to all tests in this describe block
+            beforeEach(inject(function (_$compile_, _$rootScope_, _$timeout_) {
+                // The injector unwraps the underscores (_) from around the parameter names when matching
+                $compile = _$compile_;
+                $timeout = _$timeout_;
+                $scope = _$rootScope_;
+                $scope.overviewOptions = {};
+                listener = jasmine.createSpy('listener');
+                preload = jasmine.createSpy('preload');
+                $scope.dynamicMarkers = [];
+                $scope.$on('mapControllerReady', function (event, args) {
+                    listener(args);
+                    $scope.mapController = args;
+                    //Mock 'getLayerPxFromLonLat' due to reliance on screen coords
+                    $scope.mapController.getMapInstance().getLayerPxFromLonLat = function(latLon) { return {x: 123,y:456}; };
+                    $scope.mapController.getMapInstance().getPixelFromLonLat = function (lonlat) { return {x: 123, y:456 };};
+                });
+                element = angular
+                    .element(
+                    '<ga-map map-element-id="gamap" framework="olv2" zoom-level="4" center-position="[130, -25]">' +
+                    '<ga-osm-layer></ga-osm-layer>' +
+                    '<ga-map-marker layer-name="myMarkerLayer" marker-lat="-20" marker-long="130" marker-icon="dummy/icon/url.png" marker-height="50" marker-width="50" />' +
+                    '<ga-map-marker layer-name="myMarkerLayer" marker-lat="-20" marker-long="130" marker-icon="dummy/icon/url.png" marker-height="50" marker-width="50" />' +
+                    '<ga-map-marker layer-name="myMarkerLayer" marker-lat="-20" marker-long="130" marker-icon="dummy/icon/url.png" marker-height="50" marker-width="50" />' +
+                    '<ga-map-marker layer-name="myMarkerLayer" marker-lat="-20" marker-long="130" marker-icon="dummy/icon/url.png" marker-height="50" marker-width="50" />' +                    '<ga-map-marker ng-repeat="marker in dynamicMarkers" ' +
+                    'layer-name="{{marker.name}}" ' +
+                    'marker-lat="{{marker.lat}}" ' +
+                    'marker-long="{{marker.lon}}" ' +
+                    'marker-icon="{{marker.url}}" ' +
+                    'marker-height="{{marker.height}}" ' +
+                    'marker-width="{{marker.width}}" />' +
+                    '</ga-map><div id="gamap"></div>');
+                $compile(element)($scope);
+                $scope.$digest();
+                $timeout.flush();
+            }));
+            //Tests
+            it('Should have called event "mapControllerReady" with mapController', function () {
+                expect($scope.mapController !== null);
+                expect(listener).toHaveBeenCalledWith($scope.mapController);
+            });
+
+
+            it('Should create markers, reusing the same same layer', function () {
+                var mapInstance = $scope.mapController.getMapInstance();
+                //One for OSM, one for shared marker layer
+                expect(mapInstance.layers.length).toBe(2);
+
+            });
+
+            it('Should create markers via mapController, reusing the same same layer', function () {
+                var mapInstance = $scope.mapController.getMapInstance();
+                //One for OSM, one for shared marker layer
+                expect(mapInstance.layers.length).toBe(2);
+                $scope.mapController.setMapMarker({lat:-20,lon:130},'foo','/test/foo.png',{width:'50',height:'50'});
+                $scope.mapController.setMapMarker({lat:-20,lon:130},'foo','/test/foo.png',{width:'50',height:'50'});
+                $scope.mapController.setMapMarker({lat:-20,lon:130},'foo','/test/foo.png',{width:'50',height:'50'});
+
+                expect(mapInstance.layers.length).toBe(3);
+
+            });
+
+            it('Should have 4 markers on the one layer', function () {
+                var mapInstance = $scope.mapController.getMapInstance();
+                //One for OSM, one for shared marker layer
+                expect(mapInstance.layers.length).toBe(2);
+                expect(mapInstance.layers[1].markers != null).toBe(true);
+                expect(mapInstance.layers[1].markers.length).toBe(4);
+
+            });
+
+            it('Should be able to create markers dynamically from an ng-repeat', function () {
+                var mapInstance = $scope.mapController.getMapInstance();
+                //One for OSM, one for shared marker layer
+                expect(mapInstance.layers.length).toBe(2);
+                expect(mapInstance.layers[1].markers != null).toBe(true);
+                expect(mapInstance.layers[1].markers.length).toBe(4);
+
+                $scope.dynamicMarkers.push({
+                    name: 'myMarkerLayer',
+                    lat: -20,
+                    lon: 130,
+                    url: '/dummy/path.png',
+                    height: '50px',
+                    width: '50px'
+                });
+
+                $scope.$digest();
+
+                expect(mapInstance.layers[1].markers.length).toBe(5);
+
+            });
+
+            it('Should be able to destroy markers dynamically from an ng-repeat', function () {
+                var mapInstance = $scope.mapController.getMapInstance();
+                //One for OSM, one for shared marker layer
+                expect(mapInstance.layers.length).toBe(2);
+                expect(mapInstance.layers[1].markers != null).toBe(true);
+                expect(mapInstance.layers[1].markers.length).toBe(4);
+
+                $scope.dynamicMarkers.push({
+                    name: 'myMarkerLayer',
+                    lat: -20,
+                    lon: 130,
+                    url: '/dummy/path.png',
+                    height: '50px',
+                    width: '50px'
+                });
+
+                $scope.$digest();
+
+                expect(mapInstance.layers[1].markers.length).toBe(5);
+                $scope.dynamicMarkers.pop();
+
+                $scope.$digest();
+
+                expect(mapInstance.layers[1].markers.length).toBe(4);
+            });
+
+        });
+})();

--- a/src/test/js/unit/gawebtoolkit_olv3_mapSpec.js
+++ b/src/test/js/unit/gawebtoolkit_olv3_mapSpec.js
@@ -246,18 +246,25 @@
                 } catch (e) {
                 }
                 expect(passed).toBe(true);
-            });
+            });*/
             it('Should fire mapController function "getPixelFromLonLat" with an exception given invalid input', function () {
-                var passed = false;
+                var lonPassed = false;
+                var latPassed = false;
                 try {
-                    $scope.mapController.getPixelFromLonLat(null, null);
-                    passed = false;
-                } catch (e) {
-                    passed = true;
+                    $scope.mapController.getPixelFromLonLat(null, 123);
+                } catch(e) {
+                    lonPassed = true;
                 }
-                expect(passed).toBe(true);
+
+                try {
+                    $scope.mapController.getPixelFromLonLat(123, null);
+                } catch(e) {
+                    latPassed = true;
+                }
+
+                expect(lonPassed).toBe(true);
+                expect(latPassed).toBe(true);
             });
-             */
             it('Should fire mapController function "getPointFromEvent" without an exception given valid input', function () {
                 var passed = false;
                 try {

--- a/src/test/js/unit/gawebtoolkit_olv3_markerSpec.js
+++ b/src/test/js/unit/gawebtoolkit_olv3_markerSpec.js
@@ -1,0 +1,138 @@
+/* global describe, beforeEach, module, angular, inject, it, expect, jasmine */
+(function () {
+    "use strict";
+
+    describe(
+        'OpenLayers v3 "ga-map-marker" implementation tests',
+        function () {
+            var $compile, $scope, $timeout, element, listener, preload;
+
+            // Load the myApp module, which contains the directive
+            beforeEach(module('testApp'));
+
+            // Store references to $rootScope and $compile
+            // so they are available to all tests in this describe block
+            beforeEach(inject(function (_$compile_, _$rootScope_, _$timeout_) {
+                // The injector unwraps the underscores (_) from around the parameter names when matching
+                $compile = _$compile_;
+                $timeout = _$timeout_;
+                $scope = _$rootScope_;
+                $scope.overviewOptions = {};
+                listener = jasmine.createSpy('listener');
+                preload = jasmine.createSpy('preload');
+                $scope.dynamicMarkers = [];
+                $scope.$on('mapControllerReady', function (event, args) {
+                    listener(args);
+                    $scope.mapController = args;
+                    //Mock 'getLayerPxFromLonLat' due to reliance on screen coords
+                    $scope.mapController.getMapInstance().getPixelFromCoordinate = function(coord) { return [123,456]; };
+                    ol.geom.Point.prototype.computeExtent = function(extent) {
+                        return ol.extent.createOrUpdateFromCoordinate([12,34], extent);
+                    };
+
+                });
+                element = angular
+                    .element(
+                    '<ga-map map-element-id="gamap" framework="olv3" zoom-level="4" center-position="[130, -25]">' +
+                    '<ga-osm-layer></ga-osm-layer>' +
+                    '<ga-map-marker layer-name="myMarkerLayer" marker-lat="-20" marker-long="130" marker-icon="dummy/icon/url.png" marker-height="50" marker-width="50" />' +
+                    '<ga-map-marker layer-name="myMarkerLayer" marker-lat="-20" marker-long="130" marker-icon="dummy/icon/url.png" marker-height="50" marker-width="50" />' +
+                    '<ga-map-marker layer-name="myMarkerLayer" marker-lat="-20" marker-long="130" marker-icon="dummy/icon/url.png" marker-height="50" marker-width="50" />' +
+                    '<ga-map-marker layer-name="myMarkerLayer" marker-lat="-20" marker-long="130" marker-icon="dummy/icon/url.png" marker-height="50" marker-width="50" />' +
+                    '<ga-map-marker ng-repeat="marker in dynamicMarkers" ' +
+                    'layer-name="{{marker.name}}" ' +
+                    'marker-lat="{{marker.lat}}" ' +
+                    'marker-long="{{marker.lon}}" ' +
+                    'marker-icon="{{marker.url}}" ' +
+                    'marker-height="{{marker.height}}" ' +
+                    'marker-width="{{marker.width}}" />' +
+                    '</ga-map><div id="gamap"></div>');
+                $compile(element)($scope);
+                $scope.$digest();
+                $timeout.flush();
+            }));
+            //Tests
+            it('Should have called event "mapControllerReady" with mapController', function () {
+                expect($scope.mapController !== null);
+                expect(listener).toHaveBeenCalledWith($scope.mapController);
+            });
+
+
+            it('Should create markers, reusing the same same layer', function () {
+                var mapInstance = $scope.mapController.getMapInstance();
+                //One for OSM, one for shared marker layer
+                expect(mapInstance.getLayers().getLength()).toBe(2);
+
+            });
+
+            it('Should create markers via mapController, reusing the same same layer', function () {
+                var mapInstance = $scope.mapController.getMapInstance();
+                //One for OSM, one for shared marker layer
+                expect(mapInstance.getLayers().getLength()).toBe(2);
+                $scope.mapController.setMapMarker({lat:-20,lon:130},'foo','/test/foo.png',{width:'50',height:'50'});
+                $scope.mapController.setMapMarker({lat:-20,lon:130},'foo','/test/foo.png',{width:'50',height:'50'});
+                $scope.mapController.setMapMarker({lat:-20,lon:130},'foo','/test/foo.png',{width:'50',height:'50'});
+
+                expect(mapInstance.getLayers().getLength()).toBe(3);
+
+            });
+
+            it('Should have 4 markers on the one layer', function () {
+                var mapInstance = $scope.mapController.getMapInstance();
+                //One for OSM, one for shared marker layer
+                expect(mapInstance.getLayers().getLength()).toBe(2);
+                expect(mapInstance.getLayers().item(1).getSource().getFeatures() != null).toBe(true);
+                expect(mapInstance.getLayers().item(1).getSource().getFeatures().length).toBe(4);
+
+            });
+
+            it('Should be able to create markers dynamically from an ng-repeat', function () {
+                var mapInstance = $scope.mapController.getMapInstance();
+                //One for OSM, one for shared marker layer
+                expect(mapInstance.getLayers().getLength()).toBe(2);
+                expect(mapInstance.getLayers().item(1).getSource().getFeatures() != null).toBe(true);
+                expect(mapInstance.getLayers().item(1).getSource().getFeatures().length).toBe(4);
+
+                $scope.dynamicMarkers.push({
+                    name: 'myMarkerLayer',
+                    lat: -20,
+                    lon: 130,
+                    url: '/dummy/path.png',
+                    height: '50px',
+                    width: '50px'
+                });
+
+                $scope.$digest();
+
+                expect(mapInstance.getLayers().item(1).getSource().getFeatures().length).toBe(5);
+
+            });
+
+            it('Should be able to destroy markers dynamically from an ng-repeat', function () {
+                var mapInstance = $scope.mapController.getMapInstance();
+                //One for OSM, one for shared marker layer
+                expect(mapInstance.getLayers().getLength()).toBe(2);
+                expect(mapInstance.getLayers().item(1).getSource().getFeatures() != null).toBe(true);
+                expect(mapInstance.getLayers().item(1).getSource().getFeatures().length).toBe(4);
+
+                $scope.dynamicMarkers.push({
+                    name: 'myMarkerLayer',
+                    lat: -20,
+                    lon: 130,
+                    url: '/dummy/path.png',
+                    height: '50px',
+                    width: '50px'
+                });
+
+                $scope.$digest();
+
+                expect(mapInstance.getLayers().item(1).getSource().getFeatures().length).toBe(5);
+                $scope.dynamicMarkers.pop();
+
+                $scope.$digest();
+
+                expect(mapInstance.getLayers().item(1).getSource().getFeatures().length).toBe(4);
+            });
+
+        });
+})();


### PR DESCRIPTION
Map marker directive improvements to make placing a static marker on the map simple and easier from server generated HTML.

`ga-map-marker` directive binds info like icon url, size and lat lon of the marker in display projection coordinates. Eg, to create an OSM map with a static marker.

```
<ga-map framework="olv3" map-element-id="map" zoom-level="4" center-position="[130, -25]">
    <ga-osm-layer></ga-osm-layer>
    <ga-map-marker layer-name="my marker group"
           marker-lat="-20"
           marker-long="130"
           marker-icon="http://upload.wikimedia.org/wikipedia/commons/8/86/Map_marker_icon_%E2%80%93_Nicolas_Mollet_%E2%80%93_Bowling_%E2%80%93_Culture_%26_Entertainment_%E2%80%93_Dark.png"
           marker-width="32" marker-height="37"></ga-map-marker>
</ga-map>
```

![image](https://cloud.githubusercontent.com/assets/234642/7830047/da2d49a6-048b-11e5-9d36-696ea16bed1d.png)

Functionality is kept the same across both versions of OpenLayers.

![image](https://cloud.githubusercontent.com/assets/234642/7830074/169ea72c-048c-11e5-856a-bfb09e185b05.png)

Marker layers are processed to be on top of over layers by default and markers with a common `layer-name` are grouped onto the same logical layer.